### PR TITLE
add share btn to new item details

### DIFF
--- a/src/berniesanders/berniesanders/Deserializers/ConcreteNewsItemDeserializer.swift
+++ b/src/berniesanders/berniesanders/Deserializers/ConcreteNewsItemDeserializer.swift
@@ -23,8 +23,10 @@ public class ConcreteNewsItemDeserializer : NewsItemDeserializer {
             var date = dateFormatter.dateFromString(pubDate)!
             var imageURLString = sourceDictionary["img_url"] as! String
             var imageURL = NSURL(string: imageURLString)!
+            var urlString = sourceDictionary["url"] as! String
+            var url = NSURL(string: urlString)!
             
-            var newsItem = NewsItem(title: title, date: date, body: body, imageURL: imageURL)
+            var newsItem = NewsItem(title: title, date: date, body: body, imageURL: imageURL, url: url)
             newsItems.append(newsItem);
         }
         

--- a/src/berniesanders/berniesanders/Models/NewsItem.swift
+++ b/src/berniesanders/berniesanders/Models/NewsItem.swift
@@ -5,11 +5,13 @@ public class NewsItem {
     public let date: NSDate!
     public let body: String!
     public let imageURL: NSURL!
+    public let url: NSURL!
     
-    public init(title: String, date: NSDate, body: String, imageURL: NSURL) {
+    public init(title: String, date: NSDate, body: String, imageURL: NSURL, url: NSURL) {
         self.title = title
         self.date = date
         self.body = body
         self.imageURL = imageURL
+        self.url = url
     }
 }

--- a/src/berniesanders/berniesanders/View Controllers/NewsItemController.swift
+++ b/src/berniesanders/berniesanders/View Controllers/NewsItemController.swift
@@ -36,6 +36,7 @@ public class NewsItemController : UIViewController {
         super.viewDidLoad()
         
         self.view.backgroundColor = self.theme.defaultBackgroundColor()
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Action, target: self, action: "share")
 
         self.view.addSubview(self.scrollView)
         self.scrollView.addSubview(self.containerView)
@@ -62,6 +63,13 @@ public class NewsItemController : UIViewController {
 
     required public init(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: Selectors
+    
+    func share() {
+        let activityVC = UIActivityViewController(activityItems: [newsItem.url], applicationActivities: nil)
+        presentViewController(activityVC, animated: true, completion: nil)
     }
     
     // MARK: Private

--- a/src/berniesanders/berniesandersTests/Providers/ConcreteNewsItemControllerProviderSpec.swift
+++ b/src/berniesanders/berniesandersTests/Providers/ConcreteNewsItemControllerProviderSpec.swift
@@ -21,7 +21,7 @@ public class ConcreteNewsItemControllerProviderSpec : QuickSpec {
             }
             
             it("should return a correctly configured instance") {
-                let newsItem = NewsItem(title: "a", date: NSDate(), body: "a body", imageURL: NSURL())
+                let newsItem = NewsItem(title: "a", date: NSDate(), body: "a body", imageURL: NSURL(), url: NSURL())
                 
                 let controller = self.subject.provideInstanceWithNewsItem(newsItem)
                 

--- a/src/berniesanders/berniesandersTests/Repositories/ConcreteNewsItemRepositorySpec.swift
+++ b/src/berniesanders/berniesandersTests/Repositories/ConcreteNewsItemRepositorySpec.swift
@@ -11,7 +11,7 @@ class NewsItemRepositoryFakeURLProvider: FakeURLProvider {
 
 class FakeNewsItemDeserializer: NewsItemDeserializer {
     var lastReceivedJSONDictionary: NSDictionary!
-    let returnedNewsItems = [NewsItem(title: "fake news", date: NSDate(), body: "fake body", imageURL: NSURL())]
+    let returnedNewsItems = [NewsItem(title: "fake news", date: NSDate(), body: "fake body", imageURL: NSURL(), url: NSURL())]
     
     func deserializeNewsItems(jsonDictionary: NSDictionary) -> Array<NewsItem> {
         self.lastReceivedJSONDictionary = jsonDictionary

--- a/src/berniesanders/berniesandersTests/View Controllers/NewsItemControllerSpec.swift
+++ b/src/berniesanders/berniesandersTests/View Controllers/NewsItemControllerSpec.swift
@@ -37,11 +37,12 @@ class NewsItemControllerSpec : QuickSpec {
     var subject: NewsItemController!
     let imageRepository = FakeImageRepository()
     let newsItemImageURL = NSURL(string: "http://a.com")!
+    let newsItemURL = NSURL(string: "http//b.com")!
     
     override func spec() {
         beforeEach {
             let newsItemDate = NSDate(timeIntervalSince1970: 1441081523)
-            let newsItem = NewsItem(title: "some title", date: newsItemDate, body: "some body text", imageURL: self.newsItemImageURL)
+            let newsItem = NewsItem(title: "some title", date: newsItemDate, body: "some body text", imageURL: self.newsItemImageURL, url:self.newsItemURL)
             let dateFormatter = NSDateFormatter()
             dateFormatter.dateStyle = NSDateFormatterStyle.ShortStyle
             dateFormatter.timeZone = NSTimeZone(name: "UTC")
@@ -62,6 +63,12 @@ class NewsItemControllerSpec : QuickSpec {
         describe("when the view loads") {
             beforeEach {
                 self.subject.view.layoutIfNeeded()
+            }
+            
+            it("has a share button on the navigation item") {
+                var shareBarButtonItem = self.subject.navigationItem.rightBarButtonItem!
+                expect(shareBarButtonItem.valueForKey("systemItem") as? Int).to(equal(UIBarButtonSystemItem.Action.rawValue))
+                expect(shareBarButtonItem.action).to(equal("share"))
             }
             
             it("has a scroll view containing the UI elements") {

--- a/src/berniesanders/berniesandersTests/View Controllers/NewsTableViewControllerSpec.swift
+++ b/src/berniesanders/berniesandersTests/View Controllers/NewsTableViewControllerSpec.swift
@@ -44,7 +44,7 @@ class FakeNewsItemRepository : berniesanders.NewsItemRepository {
 }
 
 class FakeNewsItemControllerProvider : berniesanders.NewsItemControllerProvider {
-    let controller = NewsItemController(newsItem: NewsItem(title: "a", date: NSDate(), body: "a body", imageURL: NSURL()), dateFormatter: NSDateFormatter(), imageRepository: FakeImageRepository(), theme: FakeTheme())
+    let controller = NewsItemController(newsItem: NewsItem(title: "a", date: NSDate(), body: "a body", imageURL: NSURL(), url: NSURL()), dateFormatter: NSDateFormatter(), imageRepository: FakeImageRepository(), theme: FakeTheme())
     var lastNewsItem: NewsItem?
     
     func provideInstanceWithNewsItem(newsItem: NewsItem) -> NewsItemController {
@@ -124,8 +124,8 @@ class NewsTableViewControllerSpecs: QuickSpec {
                 var newsItemBDate = NSDate(timeIntervalSince1970: 86401)
                 
                 beforeEach {
-                    var newsItemA = NewsItem(title: "Bernie to release new album", date: newsItemADate, body: "yeahhh", imageURL: NSURL())
-                    var newsItemB = NewsItem(title: "Bernie up in the polls!", date: newsItemBDate, body: "body text", imageURL: NSURL())
+                    var newsItemA = NewsItem(title: "Bernie to release new album", date: newsItemADate, body: "yeahhh", imageURL: NSURL(), url: NSURL())
+                    var newsItemB = NewsItem(title: "Bernie up in the polls!", date: newsItemBDate, body: "body text", imageURL: NSURL(), url: NSURL())
 
                     var newsItems = [newsItemA, newsItemB]
                     self.newsItemRepository.lastCompletionBlock!(newsItems)
@@ -155,12 +155,12 @@ class NewsTableViewControllerSpecs: QuickSpec {
         }
         
         describe("Tapping on a news item") {
-            let expectedNewsItem = NewsItem(title: "B", date: NSDate(), body: "B Body", imageURL: NSURL())
+            let expectedNewsItem = NewsItem(title: "B", date: NSDate(), body: "B Body", imageURL: NSURL(), url: NSURL())
             
             beforeEach {
                 self.subject.view.layoutIfNeeded()
                 self.subject.viewWillAppear(false)
-                var newsItemA = NewsItem(title: "A", date: NSDate(), body: "A Body", imageURL: NSURL())
+                var newsItemA = NewsItem(title: "A", date: NSDate(), body: "A Body", imageURL: NSURL(), url: NSURL())
             
                 var newsItems = [newsItemA, expectedNewsItem]
                 


### PR DESCRIPTION
A `NewsItem` object now has a story URL, and a share button appears on the News Item Details screen to share that story URL.

https://www.pivotaltracker.com/story/show/102472808
