### PR TITLE
Fix rake tasks by adding nil default to archive_and_deliver method

### DIFF
--- a/script/tasks/delivery.rake
+++ b/script/tasks/delivery.rake
@@ -48,6 +48,6 @@ def tag_version
   system("git tag '#{marketing_version}_#{build_number}'")
 end
 
-def archive_and_deliver(environment:)
+def archive_and_deliver(environment:nil)
   system("./script/archive_and_deliver #{environment}")
 end


### PR DESCRIPTION
`rake -T` was hitting a syntax error

```
rake aborted!
SyntaxError: /Users/adamprice/Code/Bernie/Connect-iOS/script/tasks/delivery.rake:51: syntax error, unexpected ')'
/Users/adamprice/Code/Bernie/Connect-iOS/script/tasks/delivery.rake:53: syntax error, unexpected keyword_end, expecting end-of-input

(See full trace by running task with --trace)
```
