### PR TITLE
Fix for #116944983

### DIFF
--- a/src/Connect/Connect/News/UI/NewsFeedController.swift
+++ b/src/Connect/Connect/News/UI/NewsFeedController.swift
@@ -127,8 +127,11 @@ class NewsFeedController: UIViewController {
             self.errorLoadingNews = false
             self.collectionView.hidden = false
             self.loadingIndicatorView.stopAnimating()
-            self.newsFeedItems = newsFeedItems
-            self.collectionView.reloadData()
+
+			if self.newsFeedItems != newsFeedItems {
+				self.newsFeedItems = newsFeedItems
+				self.collectionView.reloadData()
+			}
         }.error { error in
             self.mainQueue.addOperationWithBlock { self.refreshControl.endRefreshing() }
             self.errorLoadingNews = true
@@ -142,6 +145,20 @@ class NewsFeedController: UIViewController {
         loadNewsFeed()
     }
 }
+
+private func == (lhs: [NewsFeedItem], rhs: [NewsFeedItem]) -> Bool {
+	guard lhs.count == rhs.count else { return false }
+
+	for i in 0..<lhs.count {
+		let lItem = lhs[i]
+		let rItem = rhs[i]
+		guard lItem.identifier == rItem.identifier && lItem.date == rItem.date && lItem.title == rItem.title else { return false }
+	}
+
+	return true
+}
+
+private func != (lhs: [NewsFeedItem], rhs: [NewsFeedItem]) -> Bool { return !(lhs == rhs) }
 
 
 // MARK: UICollectionViewDataSource


### PR DESCRIPTION
> All thumbnails on News feed "flash" a moment after the user lands on the News tab

The cells themselves are behaving fine, the problem is just that the collection view isn't giving us the same cells for each indexPath when it gets reloaded each time, so the images get replaced every time. (There may be a little room for improvement in the cells that actually do end up getting the same indexPath, but they seem few and far between anyways).

So, I just made it so it doesn't reload if the fetched news items are the same as the current items.
